### PR TITLE
Safe destructuring of cell returned by section manager in getComputedStyle

### DIFF
--- a/src/VirtualCollection.vue
+++ b/src/VirtualCollection.vue
@@ -104,7 +104,13 @@ export default {
         },
         getComputedStyle(displayItem) {
             if (!displayItem) return
-            const { width, height, x, y } = this._sectionManager.getCellMetadata(displayItem.index)
+
+            // display items may have been unregistered from section manager
+            // if collection items have been removed
+            const cell = this._sectionManager.getCellMetadata(displayItem.index)
+            if (!cell) return
+            
+            const { width, height, x, y } = cell
             return {
                 left: `${x}px`,
                 top: `${y}px`,


### PR DESCRIPTION
Resolves #9.

Checks that a cell exists in the section manager corresponding to a display item before trying to destructure it. This is necessary because it seems that the `displayItems` collection lags behind the cells registered to the section manager when you remove items from the collection. This causes a stream of errors relating to out-of-bounds array access to appear in the console if you're constantly removing items.

I wasn't sure if it would be possible to add a unit test for this. However, all existing unit tests continue to pass with these changes, and I've been able to verify that it resolves the issue by sym-linking the version of this library with my changes into the project where I observed it.