### PR TITLE
Performance enhancement feature: Item groups

### DIFF
--- a/dev/src/FlatItems.vue
+++ b/dev/src/FlatItems.vue
@@ -1,0 +1,37 @@
+<template>
+    <div>
+        <VirtualCollection :cellSizeAndPositionGetter="cellSizeAndPositionGetter" :collection="items" :height="500" :width="330">
+            <div slot="cell" slot-scope="props">{{props.data}}</div>
+        </VirtualCollection>
+    </div>
+</template>
+
+<script>
+export default {
+    data() {
+        return {
+            /**
+             * This will create 1000 items like:
+             * [
+             *   { data: '#0' },
+             *   { data: '#1' },
+             *   ...
+             *   { data: '#999' }
+             * ]
+             */
+            items: new Array(1000).fill(0).map((_, index) => ({ data: "#" + index }))
+        }
+    },
+    methods: {
+        cellSizeAndPositionGetter(item, index) {
+            // compute size and position
+            return {
+                width: 100,
+                height: 150,
+                x: (index % 2) * 110,
+                y: parseInt(index / 2) * 160
+            }
+        }
+    }
+}
+</script>

--- a/dev/src/GroupedItems.vue
+++ b/dev/src/GroupedItems.vue
@@ -1,0 +1,67 @@
+<template>
+    <div class="container">
+        <div>
+          <button @click="addGroup">Add group</button>
+          <button @click="deleteGroup">Delete group</button>
+          <button @click="addItem">Add item</button>
+          <button @click="mutateItem">Mutate item</button>
+          <button @click="deleteItem">Delete item</button>
+        </div>
+        <VirtualCollection :cellSizeAndPositionGetter="cellSizeAndPositionGetter" :collection="items" :height="500" :width="600">
+            <div slot="cell" slot-scope="props">{{props.data}}</div>
+        </VirtualCollection>
+    </div>
+</template>
+
+<script>
+export default {
+    data() {
+        return {
+            items: [
+                { group: new Array(10).fill(0).map((_, index) => ({ data: "#" + index })) },
+                { group: new Array(5).fill(0).map((_, index) => ({ data: "#" + (index + 10) })) },
+                { group: new Array(3).fill(0).map((_, index) => ({ data: "#" + (index + 15) })) }
+            ]
+        }
+    },
+    methods: {
+        cellSizeAndPositionGetter(item, itemIndex, groupIndex) {
+            // compute size and position
+            return {
+                width: 100,
+                height: 150,
+                x: (groupIndex * 2 + itemIndex % 2) * 110,
+                y: parseInt(itemIndex / 2) * 160
+            }
+        },
+        addGroup() {
+            console.log("Adding group")
+            this.items.unshift({ group: [{ data: "baz" }] })
+        },
+        deleteGroup() {
+            console.log("Deleting group")
+            this.items.shift()
+        },
+        addItem() {
+            console.log("Adding item to first group")
+            this.items[0].group.unshift({ data: "foo" })
+        },
+        mutateItem() {
+            console.log("Modifying item in first group")
+            this.items[0].group[0].data = "bar"
+        },
+        deleteItem() {
+            console.log("Deleting item in first group")
+            this.items[0].group.shift()
+        }
+    }
+}
+</script>
+
+<style scoped>
+.container {
+    display: grid;
+    grid-template-rows: auto 1fr;
+    grid-row-gap: 10px;
+}
+</style>

--- a/dev/src/index.vue
+++ b/dev/src/index.vue
@@ -1,66 +1,34 @@
 <template>
-    <div>
-        <button @click="addGroup">Add group</button>
-        <button @click="deleteGroup">Delete group</button>
-        <button @click="addItem">Add item</button>
-        <button @click="mutateItem">Mutate item</button>
-        <button @click="deleteItem">Delete item</button>
-        <VirtualCollection :cellSizeAndPositionGetter="cellSizeAndPositionGetter" :collection="items" :height="500" :width="600">
-            <div slot="cell" slot-scope="props">{{props.data}}</div>
-        </VirtualCollection>
+    <div class="container">
+        <button @click="groupItems = !groupItems">
+            {{ groupItems ? "Flatten items" : "Group items" }}
+        </button>
+        <GroupedItems v-if="groupItems" />
+        <FlatItems v-else />
     </div>
 </template>
 
 <script>
-    export default {
-        data () {
-            return {
-                /**
-                 * This will create 1000 items like:
-                 * [
-                 *   { data: '#0' },
-                 *   { data: '#1' },
-                 *   ...
-                 *   { data: '#999' }
-                 * ]
-                 */
-                items: [
-                    { group: new Array(10).fill(0).map((_, index) => ({ data: '#' + index })) },
-                    { group: new Array(5).fill(0).map((_, index) => ({ data: '#' + (index + 10) })) },
-                    { group: new Array(3).fill(0).map((_, index) => ({ data: '#' + (index + 15) })) },
-                ],
-            }
-        },
-        methods: {
-            cellSizeAndPositionGetter(item, itemIndex, groupIndex) {
-                // compute size and position
-                return {
-                    width: 100,
-                    height: 150,
-                    x: (groupIndex * 2 + itemIndex % 2) * 110,
-                    y: parseInt(itemIndex / 2) * 160
-                }
-            },
-            addGroup() {
-                console.log("Adding group")
-                this.items.unshift({ group: [{ data: "baz" }] })
-            },
-            deleteGroup() {
-                console.log("Deleting group")
-                this.items.shift()
-            },
-            addItem() {
-                console.log("Adding item to first group");
-                this.items[0].group.unshift({ data: "foo" })
-            },
-            mutateItem() {
-                console.log("Modifying item in first group")
-                this.items[0].group[0].data = "bar";
-            },
-            deleteItem() {
-                console.log("Deleting item in first group")
-                this.items[0].group.shift()
-            }
+import GroupedItems from "./GroupedItems"
+import FlatItems from "./FlatItems"
+export default {
+    components: {
+        GroupedItems,
+        FlatItems
+    },
+    data() {
+        return {
+            groupItems: false
         }
     }
+}
 </script>
+
+<style scoped>
+.container {
+    display: grid;
+    grid-template-rows: auto 1fr;
+    justify-items: start;
+    grid-row-gap: 10px;
+}
+</style>

--- a/dev/src/index.vue
+++ b/dev/src/index.vue
@@ -1,6 +1,11 @@
 <template>
     <div>
-        <VirtualCollection :cellSizeAndPositionGetter="cellSizeAndPositionGetter" :collection="items" :height="500" :width="330">
+        <button @click="addGroup">Add group</button>
+        <button @click="deleteGroup">Delete group</button>
+        <button @click="addItem">Add item</button>
+        <button @click="mutateItem">Mutate item</button>
+        <button @click="deleteItem">Delete item</button>
+        <VirtualCollection :cellSizeAndPositionGetter="cellSizeAndPositionGetter" :collection="items" :height="500" :width="600">
             <div slot="cell" slot-scope="props">{{props.data}}</div>
         </VirtualCollection>
     </div>
@@ -19,18 +24,42 @@
                  *   { data: '#999' }
                  * ]
                  */
-                items: new Array(1000).fill(0).map((_, index) => ({ data: '#' + index }))
+                items: [
+                    { group: new Array(10).fill(0).map((_, index) => ({ data: '#' + index })) },
+                    { group: new Array(5).fill(0).map((_, index) => ({ data: '#' + (index + 10) })) },
+                    { group: new Array(3).fill(0).map((_, index) => ({ data: '#' + (index + 15) })) },
+                ],
             }
         },
         methods: {
-            cellSizeAndPositionGetter(item, index) {
+            cellSizeAndPositionGetter(item, itemIndex, groupIndex) {
                 // compute size and position
                 return {
                     width: 100,
                     height: 150,
-                    x: (index % 2) * 110,
-                    y: parseInt(index / 2) * 160
+                    x: (groupIndex * 2 + itemIndex % 2) * 110,
+                    y: parseInt(itemIndex / 2) * 160
                 }
+            },
+            addGroup() {
+                console.log("Adding group")
+                this.items.unshift({ group: [{ data: "baz" }] })
+            },
+            deleteGroup() {
+                console.log("Deleting group")
+                this.items.shift()
+            },
+            addItem() {
+                console.log("Adding item to first group");
+                this.items[0].group.unshift({ data: "foo" })
+            },
+            mutateItem() {
+                console.log("Modifying item in first group")
+                this.items[0].group[0].data = "bar";
+            },
+            deleteItem() {
+                console.log("Deleting item in first group")
+                this.items[0].group.shift()
             }
         }
     }

--- a/src/GroupManager.js
+++ b/src/GroupManager.js
@@ -1,0 +1,60 @@
+import SectionManager from "./SectionManager";
+
+/** Represents a group of logically-related items */
+export default class GroupManager {
+    constructor (group, groupId, sectionSize, cellSizeAndPositionGetter, unwatch) {
+        this._groupId = groupId
+        this._sectionSize = sectionSize
+        this._cellSizeAndPositionGetter = cellSizeAndPositionGetter;
+        this._unwatch = unwatch
+        this.totalHeight = 0
+        this.totalWidth = 0
+        this.updateGroup(group)
+    }
+
+    updateGroup(group) {
+        const sectionManager = new SectionManager(this._sectionSize)
+        let totalHeight = 0
+        let totalWidth = 0
+
+        group.forEach((item, index) => {
+            const cellMetadatum = this._cellSizeAndPositionGetter(item, index, this._groupId)
+            sectionManager.registerCell({
+                index,
+                cellMetadatum
+            })
+            
+            // compute total height and total width
+            const { x, y, width, height } = cellMetadatum
+            const bottom = y + height
+            const right = x + width
+            if (bottom > totalHeight) {
+                totalHeight = bottom
+            }
+            if (right > totalWidth) {
+                totalWidth = right
+            }
+        })
+        
+        this._group = group
+        this._sectionManager = sectionManager
+        this.totalHeight = totalHeight
+        this.totalWidth = totalWidth
+    }
+
+    getCellIndices(region) {
+        return this._sectionManager.getCellIndices(region);
+    }
+
+    getCellMetadata(index) {
+        return this._sectionManager.getCellMetadata(index)
+    }
+
+    getItem(index) {
+        return this._group[index]
+    }
+
+    dispose() {
+        this._unwatch()
+    }
+}

--- a/src/GroupManager.js
+++ b/src/GroupManager.js
@@ -35,6 +35,8 @@ export default class GroupManager {
                 totalWidth = right
             }
         })
+
+        sectionManager.freezeCells()
         
         this._group = group
         this._sectionManager = sectionManager

--- a/src/SectionManager.js
+++ b/src/SectionManager.js
@@ -11,9 +11,14 @@ export default class SectionManager {
     }
 
     registerCell({ cellMetadatum, index }) {
-        this._cellMetadata[index] = cellMetadatum
+        const frozenCellMetadatum = Object.freeze(cellMetadatum);
+        this._cellMetadata[index] = frozenCellMetadatum
 
-        this.getSections(cellMetadatum).forEach(section => section.addCellIndex({ index }))
+        this.getSections(frozenCellMetadatum).forEach(section => section.addCellIndex({ index }))
+    }
+
+    freezeCells() {
+        Object.freeze(this._cellMetadata)
     }
 
     /** Get all Sections overlapping the specified region. */

--- a/src/VirtualCollection.vue
+++ b/src/VirtualCollection.vue
@@ -79,8 +79,15 @@ export default {
         onCollectionChanged() {
             console.log("Collection changed")
 
+            let collection = this.collection
+
+            // If the collection is flat, wrap it inside a single group
+            if (collection.length > 0 && collection[0].group === undefined) {
+                collection = [{ group: collection }]
+            }
+
             // Create and store managers for each item group
-            this.collection.forEach((groupContainer, i) => {
+            collection.forEach((groupContainer, i) => {
                 const groupIndex = i; // Capture group index for closure
                 const group = groupContainer.group
                 const unwatch = this.$watch(

--- a/src/VirtualCollection.vue
+++ b/src/VirtualCollection.vue
@@ -57,8 +57,7 @@ export default {
         return {
             totalHeight: 0,
             totalWidth: 0,
-            displayItems: [],
-            groupManagers: []
+            displayItems: []
         }
     },
     watch: {
@@ -73,6 +72,7 @@ export default {
         }
     },
     created() {
+        this.groupManagers = []
         this.onCollectionChanged()
     },
     methods: {

--- a/src/VirtualCollection.vue
+++ b/src/VirtualCollection.vue
@@ -15,7 +15,7 @@
 <template>
     <div class="vue-virtual-collection" :style="outerStyle" @scroll.passive="onScroll" ref="outer">
         <div class="vue-virtual-collection-container" :style="containerStyle">
-            <div v-for="(item, index) in displayItems" class="cell-container" :key="item.index" :style="getComputedStyle(item, index)">
+            <div v-for="item in displayItems" class="cell-container" :key="item.key" :style="getComputedStyle(item)">
                 <slot name="cell" :data="item.data"></slot>
             </div>
         </div>
@@ -23,7 +23,7 @@
 </template>
 
 <script>
-import SectionManager from "./SectionManager"
+import GroupManager from "./GroupManager"
 export default {
     props: {
         cellSizeAndPositionGetter: {
@@ -55,62 +55,74 @@ export default {
     },
     data() {
         return {
-            displayItems: [],
             totalHeight: 0,
-            totalWidth: 0
+            totalWidth: 0,
+            displayItems: [],
+            groupManagers: []
         }
     },
     watch: {
         collection() {
-            this.init()
+            // Dispose previous groups and reset associated data
+            this.groupManagers.forEach(manager => manager.dispose())
+            this.groupManagers = []
+            this.totalHeight = 0
+            this.totalWidth = 0
+
+            this.onCollectionChanged()
         }
     },
     created() {
-        this.init()
+        this.onCollectionChanged()
     },
     methods: {
-        init() {
-            this._sectionManager = new SectionManager(this.sectionSize)
-            this.registerCellsToSectionManager()
+        onCollectionChanged() {
+            console.log("Collection changed")
+
+            // Create and store managers for each item group
+            this.collection.forEach((groupContainer, i) => {
+                const groupIndex = i; // Capture group index for closure
+                const group = groupContainer.group
+                const unwatch = this.$watch(
+                    () => groupContainer,
+                    () => this.onGroupChanged(group, groupIndex),
+                    { deep: true }
+                )
+
+                this.groupManagers.push(new GroupManager(
+                    group,
+                    groupIndex,
+                    this.sectionSize,
+                    this.cellSizeAndPositionGetter,
+                    unwatch
+                ))
+            })
+
+            this.updateGridDimensions()
             this.flushDisplayItems()
         },
-        registerCellsToSectionManager() {
-            if (!this._sectionManager) {
-                this._sectionManager = new SectionManager(this.sectionSize)
-            }
-            let totalHeight = 0
-            let totalWidth = 0
-            this.collection.forEach((item, index) => {
-                // register
-                const cellMetadatum = this.cellSizeAndPositionGetter(item, index)
-                this._sectionManager.registerCell({
-                    index,
-                    cellMetadatum
-                })
-
-                // compute total height and total width
-                const { x, y, width, height } = cellMetadatum
-                const bottom = y + height
-                const right = x + width
-                if (bottom > totalHeight) {
-                    totalHeight = bottom
-                }
-                if (right > totalWidth) {
-                    totalWidth = right
-                }
-                this.totalHeight = totalHeight
-                this.totalWidth = totalWidth
-            })
+        updateGridDimensions() {
+            this.totalHeight = Math.max(...this.groupManagers.map(it => it.totalHeight))
+            this.totalWidth = Math.max(...this.groupManagers.map(it => it.totalWidth))
+        },
+        onGroupChanged(group, index) {
+            console.log("Group changed", group, index)
+            this.groupManagers[index].updateGroup(group)
+            this.updateGridDimensions()
+            this.flushDisplayItems()
         },
         getComputedStyle(displayItem) {
             if (!displayItem) return
 
-            // display items may have been unregistered from section manager
-            // if collection items have been removed
-            const cell = this._sectionManager.getCellMetadata(displayItem.index)
-            if (!cell) return
+            // Currently displayed items may no longer exist
+            // if collection has been modified since
+            const groupManager = this.groupManagers[displayItem.groupIndex];
+            if (!groupManager) return
+
+            const cellMetadatum = groupManager.getCellMetadata(displayItem.itemIndex)
+            if (!cellMetadatum) return
             
-            const { width, height, x, y } = cell
+            const { width, height, x, y } = cellMetadatum
             return {
                 left: `${x}px`,
                 top: `${y}px`,
@@ -128,19 +140,26 @@ export default {
                 scrollTop = this.$refs.outer.scrollTop
                 scrollLeft = this.$refs.outer.scrollLeft
             }
-            var indices = this._sectionManager.getCellIndices({
-                height: this.height,
-                width: this.width,
-                x: scrollLeft,
-                y: scrollTop
-            })
+            
             const displayItems = []
-            indices.forEach(index => {
-                displayItems.push({
-                    index,
-                    ...this.collection[index]
+            this.groupManagers.forEach((groupManager, groupIndex) => {
+                var indices = groupManager.getCellIndices({
+                    height: this.height,
+                    width: this.width,
+                    x: scrollLeft,
+                    y: scrollTop
+                })
+
+                indices.forEach(itemIndex => {
+                    displayItems.push({
+                        groupIndex,
+                        itemIndex,
+                        key: displayItems.length,
+                        ...groupManager.getItem(itemIndex)
+                    })
                 })
             })
+
             if (window.requestAnimationFrame) {
                 window.requestAnimationFrame(() => {
                     this.displayItems = displayItems

--- a/src/VirtualCollection.vue
+++ b/src/VirtualCollection.vue
@@ -77,8 +77,6 @@ export default {
     },
     methods: {
         onCollectionChanged() {
-            console.log("Collection changed")
-
             let collection = this.collection
 
             // If the collection is flat, wrap it inside a single group
@@ -89,15 +87,14 @@ export default {
             // Create and store managers for each item group
             collection.forEach((groupContainer, i) => {
                 const groupIndex = i; // Capture group index for closure
-                const group = groupContainer.group
                 const unwatch = this.$watch(
                     () => groupContainer,
-                    () => this.onGroupChanged(group, groupIndex),
+                    () => this.onGroupChanged(groupContainer.group, groupIndex),
                     { deep: true }
                 )
 
                 this.groupManagers.push(new GroupManager(
-                    group,
+                    groupContainer.group,
                     groupIndex,
                     this.sectionSize,
                     this.cellSizeAndPositionGetter,
@@ -113,14 +110,13 @@ export default {
             this.totalWidth = Math.max(...this.groupManagers.map(it => it.totalWidth))
         },
         onGroupChanged(group, index) {
-            console.log("Group changed", group, index)
             this.groupManagers[index].updateGroup(group)
             this.updateGridDimensions()
             this.flushDisplayItems()
         },
         getComputedStyle(displayItem) {
             if (!displayItem) return
-
+            
             // Currently displayed items may no longer exist
             // if collection has been modified since
             const groupManager = this.groupManagers[displayItem.groupIndex];
@@ -158,12 +154,12 @@ export default {
                 })
 
                 indices.forEach(itemIndex => {
-                    displayItems.push({
+                    displayItems.push(Object.freeze({
                         groupIndex,
                         itemIndex,
                         key: displayItems.length,
                         ...groupManager.getItem(itemIndex)
-                    })
+                    }))
                 })
             })
 

--- a/test/VirtualCollection.test.js
+++ b/test/VirtualCollection.test.js
@@ -12,7 +12,23 @@ function cellSizeAndPositionGetter(item, index) {
     }
 }
 
+function groupedCellSizeAndPositionGetter(item, itemIndex, groupIndex) {
+    // compute size and position
+    return {
+        width: 100,
+        height: 150,
+        x: (groupIndex * 2 + itemIndex % 2) * 110,
+        y: parseInt(itemIndex / 2) * 160
+    }
+}
+
 const items = new Array(1000).fill(0).map((_, index) => ({ data: '#' + index }))
+const groups = [
+    { group: new Array(10).fill(0).map((_, index) => ({ data: "#A" + index })) },
+    { group: new Array(10).fill(0).map((_, index) => ({ data: "#B" + index })) },
+    { group: new Array(10).fill(0).map((_, index) => ({ data: "#C" + index })) },
+    { group: new Array(10).fill(0).map((_, index) => ({ data: "#D" + index })) }
+]
 
 describe('VirtualCollection', () => {
     it('can render cells correctly', () => {
@@ -32,6 +48,29 @@ describe('VirtualCollection', () => {
         )
         expect(wrapper.findAll('.cell-container').length >= 4).to.be.true
         expect(wrapper.text()).to.be.equal('#0#1#2#3')
+    })
+
+    it('can render cells when items are grouped', () => {
+        const wrapper = shallowMount(
+            VirtualCollection,
+            {
+                propsData: {
+                    cellSizeAndPositionGetter: groupedCellSizeAndPositionGetter,
+                    collection: groups,
+                    height: 300,
+                    width: 500
+                },
+                scopedSlots: {
+                    cell: '<div slot-scope="props">{{props.data}}</div>'
+                }
+            }
+        )
+        
+        const groupA = '#A0#A1#A2#A3'
+        const groupB = '#B0#B1#B2#B3'
+        const groupC = '#C0#C1#C2#C3'
+        expect(wrapper.findAll('.cell-container').length >= 12).to.be.true
+        expect(wrapper.text()).to.be.equal(groupA + groupB + groupC)
     })
 
     it('will not render cells if width or height equals zero', () => {


### PR DESCRIPTION
Introduces an "item group" feature that can potentially improve performance for certain use cases of this library.

### Motivation

In some cases the collection you pass to a `VirtualCollection` might contain logically separate types of items that change at different rates. For example, in my case I use `VirtualCollection` to represent a 2D cartesian grid-space, with two types of objects used in the collection:

 - grid tiles
 - grid items

Grid items are arbitrary objects displayed on the grid. These are passed to the grid as props and so depend entirely on the application consuming my library. The collection of grid items may change frequently. On the other hand, grid tiles are controlled entirely by my grid library and only need to be changed ("regenerated") when the grid is resized.

As vue-virtual-collection currently treats all items in the collection equally, it will invoke `cellSizeAndPositionGetter`, register cells, etc. for every single item in the collection whenever a single item changes. Consider a case where a 100x100 grid is created and 10 grid items are placed on it. If a single grid item changes, `VirtualCollection` will perform this procedure for all 10,000 tiles and 10 grid items even though only a single grid item has changed.

However, with the concept of "item groups" I can pass grid tiles and grid items to `VirtualCollection` as separate groups, and when an item changes `VirtualCollection` will only process the *group* that contains that item. In this scenario, when a grid item changes it cuts the number of elements operated on from 10,010 to just 10, a reduction of ~99.9%. This can help significantly improve performance.

### Implementation

Clients of this library can opt-in to using groups by passing an array of objects with the form `{ group: [...] }`, where `[...]` represents the items of the collection belonging to a specific group. In the scenario given above, `:collection="[...tiles, ...items]"` would get replaced with `:collection="[ { group: [] }, { group: [] } ]"`, where the first array would be updated to contain the tiles and the second to contain the grid items.

Internally, `VirtualCollection` creates separate watchers for each group in the collection, so that any changes that are limited to a specific group of items will only cause the watcher for that group to fire.

This feature **does not present breaking changes** - it is still possible to pass a flat array of items to `:collection`, in which case it gets wrapped as a single group. This means that all existing usages of the library should work as before, without significant changes in performance. I have confirmed this is the case with my library, and all existing unit tests continue to pass.

### Benchmarks

Below is a comparison of the performance changes introduced for a demo project based on my grid library, which in turn depends on vue-virtual-collection. The profiles shown below were captured in Chrome devtools on a mid-2014 MacBook Pro running macOS High Sierra 10.13.5. For both profiles, I keep the grid stationary (so that tiles don't regenerate), so that only the grid items change.

Over the course of a second, I observe a reduction in scripting time from 191.4ms to 107.5 ms, a ~44% decrease.

#### Without Item Grouping

![Without item grouping](https://user-images.githubusercontent.com/1588951/42419358-223251d8-82ab-11e8-9bd2-9c21283282eb.png)

#### With Item Grouping

![With item grouping](https://user-images.githubusercontent.com/1588951/42419354-00237112-82ab-11e8-8982-8fabd2ed01e9.png)
