### PR TITLE
safe sectionSize

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,7 @@ Type: `number`
 
 Optionally override the size of the sections a Collection's cells are split into. This is an advanced option and should only be used for performance tuning purposes.
 
+too big or too small will cause reverse performance, will effect by ./src/VirtualCollection.vue getSmoothSectionSize()
 ## Slots
 
 ### cell

--- a/src/VirtualCollection.vue
+++ b/src/VirtualCollection.vue
@@ -99,7 +99,7 @@ export default {
                 this.groupManagers.push(new GroupManager(
                     groupContainer.group,
                     groupIndex,
-                    this.sectionSize,
+                    this.getSmoothSectionSize(),
                     this.cellSizeAndPositionGetter,
                     unwatch
                 ))
@@ -111,6 +111,13 @@ export default {
         updateGridDimensions() {
             this.totalHeight = Math.max(...this.groupManagers.map(it => it.totalHeight))
             this.totalWidth = Math.max(...this.groupManagers.map(it => it.totalWidth))
+        },
+        getSmoothSectionSize() {
+            let smoothMax = Math.max(this.height, this.width , 0) / 2 
+            let smoothMin = smoothMax / 3
+            return this.sectionSize >= smoothMin && this.sectionSize <= smoothMax
+                ? this.sectionSize
+                : (smoothMax + smoothMin) / 2
         },
         onGroupChanged(group, index) {
             this.groupManagers[index].updateGroup(group)


### PR DESCRIPTION
```html
<VirtualCollection :sectionSize="1" :cellSizeAndPositionGetter="cellSizeAndPositionGetter" :collection="items" :height="800" :width="1000" >
  <div slot="cell" slot-scope="props" class="card" :class="props.data.color">{{props.data.text}}</div>
</VirtualCollection>
```
or `sectionSize = Number.MAX_VALUE ` will may be  case browser block 